### PR TITLE
feat: Add freeze property to CollectionReference and DocumentReference

### DIFF
--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -332,7 +332,7 @@ export class AlwatrStore {
   async saveAll(): Promise<void> {
     logger.logMethod?.('saveAll');
     for (const ref of Object.values(this.cacheReferences__)) {
-      if (ref.hasUnprocessedChanges_ === true) {
+      if (ref.hasUnprocessedChanges_ === true && ref.freeze !== true) {
         ref.updateDelayed_ = false;
         await this.storeChanged__(ref);
       }
@@ -419,7 +419,7 @@ export class AlwatrStore {
     logger.logMethod?.('exitHook__');
     for (const ref of Object.values(this.cacheReferences__)) {
       logger.logProperty?.(`StoreFile.${ref.id}.hasUnprocessedChanges`, ref.hasUnprocessedChanges_);
-      if (ref.hasUnprocessedChanges_ === true) {
+      if (ref.hasUnprocessedChanges_ === true && ref.freeze !== true) {
         logger.incident?.('exitHook__', 'rescue_unsaved_context', {id: ref.id});
         writeJson(resolve(this.config__.rootPath, ref.path), ref.getFullContext_(), true);
         ref.hasUnprocessedChanges_ = false;

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -217,6 +217,43 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
     this.save();
   }
 
+
+  /**
+   * Indicates whether the collection data is frozen and cannot be saved.
+   */
+  private _freeze = false;
+
+  /**
+   * Gets the freeze status of the collection data.
+   *
+   * @returns `true` if the collection data is frozen, `false` otherwise.
+   *
+   * @example
+   * ```typescript
+   * const isFrozen = collectionRef.freeze;
+   * console.log(isFrozen); // Output: false
+   * ```
+   */
+  get freeze(): boolean {
+    return this._freeze;
+  }
+
+  /**
+   * Sets the freeze status of the collection data.
+   *
+   * @param value - The freeze status to set.
+   *
+   * @example
+   * ```typescript
+   * collectionRef.freeze = true;
+   * console.log(collectionRef.freeze); // Output: true
+   * ```
+   */
+  set freeze(value: boolean) {
+    this.logger__.logMethodArgs?.('freeze changed', { value });
+    this._freeze = value;
+  }
+
   /**
    * Checks if an item exists in the collection.
    *
@@ -556,6 +593,8 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
     this.updateDelayed_ = false;
 
     if (id === null) this.updateMeta_(id); // root meta not updated for null
+
+    if (this._freeze === true) return; // prevent save if frozen
     this.updatedCallback__.call(null, this);
   }
 

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -201,6 +201,43 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
     this.save();
   }
 
+
+  /**
+   * Indicates whether the collection data is frozen and cannot be saved.
+   */
+  private _freeze = false;
+
+  /**
+   * Gets the freeze status of the collection data.
+   *
+   * @returns `true` if the collection data is frozen, `false` otherwise.
+   *
+   * @example
+   * ```typescript
+   * const isFrozen = collectionRef.freeze;
+   * console.log(isFrozen); // Output: false
+   * ```
+   */
+  get freeze(): boolean {
+    return this._freeze;
+  }
+
+  /**
+   * Sets the freeze status of the collection data.
+   *
+   * @param value - The freeze status to set.
+   *
+   * @example
+   * ```typescript
+   * collectionRef.freeze = true;
+   * console.log(collectionRef.freeze); // Output: true
+   * ```
+   */
+  set freeze(value: boolean) {
+    this.logger__.logMethodArgs?.('freeze changed', { value });
+    this._freeze = value;
+  }
+
   /**
    * Retrieves the document's data.
    *
@@ -333,6 +370,8 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
     this.updateDelayed_ = false;
 
     this.updateMeta_();
+
+    if (this._freeze === true) return; // prevent save if frozen
     this.updatedCallback__.call(null, this);
   }
 


### PR DESCRIPTION
The code changes introduce a new `freeze` property to both the `CollectionReference` and `DocumentReference` classes. This property allows the collection or document data to be frozen, preventing it from being saved. The purpose of this change is to provide control over the save behavior when the data should not be modified or saved temporarily.
