### PR TITLE
v7!

### DIFF
--- a/packages/engine/demo/benchmark.mjs
+++ b/packages/engine/demo/benchmark.mjs
@@ -1,6 +1,6 @@
 import {createLogger} from '@alwatr/logger';
-import {AlwatrStore, StoreFileExtension, StoreFileType, Region} from '@alwatr/store-engine';
-import {waitForIdle, waitForImmediate, waitForTimeout} from '@alwatr/wait';
+import {AlwatrStore, Region} from '@alwatr/store-engine';
+import {waitForTimeout} from '@alwatr/wait';
 
 (async function () {
   const logger = createLogger('AlwatrStore/Demo', true);
@@ -18,20 +18,16 @@ import {waitForIdle, waitForImmediate, waitForTimeout} from '@alwatr/wait';
   };
 
   if (alwatrStore.exists(colId)) {
-    await alwatrStore.deleteFile(colId);
+    await alwatrStore.remove(colId);
   }
 
-  alwatrStore.defineStoreFile({
-    ...colId,
-    type: StoreFileType.Collection,
-    extension: StoreFileExtension.Json,
-  });
+  alwatrStore.newCollection(colId);
 
-  const col = await alwatrStore.collection(colId);
+  const col = await alwatrStore.openCollection(colId);
 
   await waitForTimeout(1000);
 
-  logger.time('write_10k_record_time');
+  logger.time?.('write_10k_record_time');
 
   const max = 10_000;
   for (let i = 0; i < max; i++) {
@@ -42,15 +38,15 @@ import {waitForIdle, waitForImmediate, waitForTimeout} from '@alwatr/wait';
     // await waitForImmediate();
   }
 
-  logger.timeEnd('write_10k_record_time');
+  logger.timeEnd?.('write_10k_record_time');
 
   await waitForTimeout(1000);
 
-  logger.time('access_10k_item_time');
+  logger.time?.('access_10k_item_time');
   let item;
   for (let i = 0; i < max; i++) {
-    item = col.access_(i);
+    item = col.getItemContext_(i);
   }
-  logger.timeEnd('access_10k_item_time');
-  logger.logProperty('item', item);
+  logger.timeEnd?.('access_10k_item_time');
+  logger.logProperty?.('item', item);
 })();

--- a/packages/engine/demo/collection.mjs
+++ b/packages/engine/demo/collection.mjs
@@ -34,7 +34,6 @@ async function quickstart() {
   alwatrStore.defineStoreFile({
     ...postsCollectionId,
     type: StoreFileType.Collection,
-    extension: StoreFileExtension.Json,
   });
 
   // Get a collection reference.

--- a/packages/engine/demo/collection.mjs
+++ b/packages/engine/demo/collection.mjs
@@ -1,6 +1,6 @@
 import {createLogger} from '@alwatr/logger';
 
-import {AlwatrStore, Region, StoreFileExtension, StoreFileType} from '@alwatr/store-engine';
+import {AlwatrStore, Region} from '@alwatr/store-engine';
 
 const logger = createLogger('AlwatrStore/Demo', true);
 logger.banner('AlwatrStore/Demo');
@@ -26,50 +26,47 @@ async function quickstart() {
 
   if (exists) {
     // Delete the collection store file.
-    alwatrStore.deleteFile(postsCollectionId);
+    alwatrStore.remove(postsCollectionId);
     logger.logOther?.('The collection store file deleted');
   }
 
   // Create a new collection.
-  alwatrStore.defineStoreFile({
-    ...postsCollectionId,
-    type: StoreFileType.Collection,
-  });
+  alwatrStore.newCollection(postsCollectionId);
 
   // Get a collection reference.
-  const postsCollection = await alwatrStore.collection(postsCollectionId);
+  const postsCollection = await alwatrStore.openCollection(postsCollectionId);
 
   const post1Id = 'intro-to-alwatr-store';
   const post2Id = 'intro-to-alwatr-collections';
 
   // Create new new post (new item in the collection).
-  postsCollection.create(post1Id, {
+  postsCollection.add(post1Id, {
     title: 'Welcome to Alwatr Store',
     body: 'This is a amazing content',
   });
 
   // Read the collection item meta information.
-  logger.logProperty?.('collection.meta', postsCollection.metaItem(post1Id));
+  logger.logProperty?.('collection.meta', postsCollection.getItemMetadata(post1Id));
 
   // Read the collection item.
-  logger.logProperty?.('context1', postsCollection.get(post1Id));
+  logger.logProperty?.('context1', postsCollection.getItem(post1Id));
 
   // Update an existing collection item.
   postsCollection.update(post1Id, {
     body: 'My first AlwatrStore Collection',
   });
-  logger.logProperty?.('context', postsCollection.get(post1Id));
+  logger.logProperty?.('context', postsCollection.getItem(post1Id));
 
   // post 2
 
-  postsCollection.create(post2Id, {
+  postsCollection.add(post2Id, {
     title: 'Welcome to Alwatr Collections',
     body: 'This is a amazing content',
   });
-  logger.logProperty?.('context2', postsCollection.get(post1Id));
+  logger.logProperty?.('context2', postsCollection.getItem(post1Id));
 
-  logger.logProperty?.('collection.meta1', postsCollection.metaItem(post1Id));
-  logger.logProperty?.('collection.meta2', postsCollection.metaItem(post2Id));
+  logger.logProperty?.('collection.meta1', postsCollection.getItemMetadata(post1Id));
+  logger.logProperty?.('collection.meta2', postsCollection.getItemMetadata(post2Id));
 
   // Unload the collection from memory.
   alwatrStore.unload(postsCollectionId);

--- a/packages/engine/demo/data-lost-test.js
+++ b/packages/engine/demo/data-lost-test.js
@@ -1,6 +1,6 @@
 import {createLogger} from '@alwatr/logger';
 
-import {AlwatrStore, Region, StoreFileExtension, StoreFileType} from '@alwatr/store-engine';
+import {AlwatrStore, Region} from '@alwatr/store-engine';
 
 const logger = createLogger('AlwatrStore/Demo', true);
 logger.banner('AlwatrStore/Demo');
@@ -23,14 +23,10 @@ for (let i = 0; i < 10; i++) {
   };
 
   if (!alwatrStore.exists(docId)) {
-    alwatrStore.defineStoreFile({
-      ...docId,
-      type: StoreFileType.Collection,
-      extension: StoreFileExtension.Json,
-    });
+    alwatrStore.newCollection(docId);
   }
 
-  list.push(await alwatrStore.collection(docId));
+  list.push(await alwatrStore.openCollection(docId));
 }
 
 function insertData() {

--- a/packages/engine/demo/document.mjs
+++ b/packages/engine/demo/document.mjs
@@ -1,6 +1,6 @@
 import {createLogger} from '@alwatr/logger';
 
-import {AlwatrStore, Region, StoreFileExtension, StoreFileType} from '@alwatr/store-engine';
+import {AlwatrStore, Region} from '@alwatr/store-engine';
 
 const logger = createLogger('AlwatrStore/Demo', true);
 logger.banner('AlwatrStore/Demo');
@@ -25,41 +25,34 @@ async function quickstart() {
 
   if (!exists) {
     // Define a new document store file.
-    alwatrStore.defineStoreFile(
-      {
-        ...docId,
-        type: StoreFileType.Document,
-        extension: StoreFileExtension.Json,
-      },
-      {
-        title: 'new title',
-        body: '',
-      },
-    );
+    alwatrStore.newDocument(docId, {
+      title: 'new title',
+      body: '',
+    });
   }
 
   // Create new document reference of specific id.
-  const myPost = await alwatrStore.doc(docId);
+  const myPost = await alwatrStore.openDocument(docId);
 
   // Read the document meta information.
-  logger.logProperty?.('doc.meta', myPost.meta());
+  logger.logProperty?.('doc.meta', myPost.getStoreMetadata());
 
   // Enter new data into the document.
-  myPost.set({
+  myPost.update({
     title: 'Welcome to Alwatr Store',
     body: 'This is a amazing content',
   });
 
   // Read the document.
-  logger.logProperty?.('context', myPost.get());
+  logger.logProperty?.('context', myPost.getData());
 
   // Update an existing document.
   myPost.update({
     body: 'My first AlwatrStore Document',
   });
-  logger.logProperty?.('context', myPost.get());
+  logger.logProperty?.('context', myPost.getData());
 
-  logger.logProperty?.('doc.meta', myPost.meta());
+  logger.logProperty?.('doc.meta', myPost.getStoreMetadata());
 
   await new Promise((resolve) => setTimeout(resolve, 1_000));
 

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -22,9 +22,9 @@
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/main.mjs",
-      "require": "./dist/main.cjs",
-      "types": "./dist/main.d.ts"
+      "require": "./dist/main.cjs"
     }
   },
   "license": "MIT",
@@ -60,13 +60,13 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/exit-hook": "^1.0.13",
-    "@alwatr/flat-string": "^1.0.20",
-    "@alwatr/logger": "^3.2.11",
-    "@alwatr/node-fs": "^1.0.10",
+    "@alwatr/exit-hook": "^1.0.14",
+    "@alwatr/flat-string": "^1.0.21",
+    "@alwatr/logger": "^3.2.12",
+    "@alwatr/node-fs": "^1.0.11",
     "@alwatr/store-reference": "workspace:^",
     "@alwatr/store-types": "workspace:^",
-    "@alwatr/wait": "^1.1.13"
+    "@alwatr/wait": "^1.1.14"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^1.3.8",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -50,7 +50,7 @@
     "w": "yarn run watch",
     "c": "yarn run clean",
     "cb": "yarn run clean && yarn run build",
-    "d": "ALWATR_DEBUG=1 yarn node --enable-source-maps --trace-warnings",
+    "d": "yarn node --enable-source-maps --trace-warnings",
     "build": "yarn run build:ts & yarn run build:es",
     "build:es": "nano-build --preset=module",
     "build:ts": "tsc --build",

--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -120,26 +120,81 @@ export class AlwatrStore {
   }
 
   /**
-   * Defines a AlwatrStoreFile with the given configuration and initial data.
+   * Defines a new document with the given configuration and initial data.
+   * If a document with the same ID already exists, an error is thrown.
    *
    * @param stat store file stat
    * @param initialData initial data for the document
    * @template TDoc document data type
    * @example
    * ```typescript
-   * await alwatrStore.defineDocument<Order>({
-   *  name: 'profile',
-   *  region: Region.PerUser,
-   *  ownerId: 'user1',
-   *  type: StoreFileType.Document,
-   *  extension: StoreFileExtension.Json,
-   * }, {
-   *   name: 'Ali',
-   *   email: 'ali@alwatr.io',
-   * });
+   * await alwatrStore.newDocument<Order>(
+   *   {
+   *     name: 'profile',
+   *     region: Region.PerUser,
+   *     ownerId: 'user1',
+   *   },
+   *   {
+   *     name: 'Ali',
+   *     email: 'ali@alwatr.io',
+   *   }
+   * );
    * ```
    */
-  defineStoreFile<T extends JsonifiableObject = JsonifiableObject>(
+  newDocument<T extends JsonifiableObject = JsonifiableObject>(
+    stat: Omit<StoreFileStat, 'type'>,
+    initialData: DocumentContext<T>['data'] | null = null,
+  ): void {
+    logger.logMethodArgs?.('newDocument', stat);
+    return this.newStoreFile_(
+      {
+        ...stat,
+        type: StoreFileType.Document,
+      },
+      initialData,
+    );
+  }
+
+  /**
+   * Defines a new collection with the given configuration and initial data.
+   * If a collection with the same ID already exists, an error is thrown.
+   *
+   * @param stat store file stat
+   * @param initialData initial data for the collection
+   * @template TItem collection item data type
+   * @example
+   * ```typescript
+   * await alwatrStore.newCollection<Order>(
+   *   {
+   *     name: 'orders',
+   *     region: Region.PerUser,
+   *     ownerId: 'user1',
+   *   }
+   * );
+   * ```
+   */
+  newCollection<TItem extends JsonifiableObject = JsonifiableObject>(
+    stat: Omit<StoreFileStat, 'type'>,
+    initialData: CollectionContext<TItem>['data'] | null = null,
+  ): void {
+    logger.logMethodArgs?.('newCollection', stat);
+    return this.newStoreFile_(
+      {
+        ...stat,
+        type: StoreFileType.Collection,
+      },
+      initialData,
+    );
+  }
+
+  /**
+   * Defines a AlwatrStoreFile with the given configuration and initial data.
+   *
+   * @param stat store file stat
+   * @param initialData initial data for the document
+   * @template TDoc document data type
+   */
+  newStoreFile_<T extends JsonifiableObject = JsonifiableObject>(
     stat: StoreFileStat,
     initialData: DocumentContext<T>['data'] | CollectionContext<T>['data'] | null = null,
   ): void {

--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -198,7 +198,7 @@ export class AlwatrStore {
     stat: StoreFileStat,
     initialData: DocumentContext<T>['data'] | CollectionContext<T>['data'] | null = null,
   ): void {
-    logger.logMethodArgs?.('defineStoreFile', stat);
+    logger.logMethodArgs?.('newStoreFile_', stat);
 
     (stat.changeDebounce as number | undefined) ??= this.config__.defaultChangeDebounce;
 
@@ -245,7 +245,7 @@ export class AlwatrStore {
    */
   async openDocument<TDoc extends JsonifiableObject>(id: StoreFileId): Promise<DocumentReference<TDoc>> {
     const id_ = getStoreId(id);
-    logger.logMethodArgs?.('doc', id_);
+    logger.logMethodArgs?.('openDocument', id_);
 
     if (Object.hasOwn(this.cacheReferences__, id_)) {
       const ref = this.cacheReferences__[id_];
@@ -293,7 +293,7 @@ export class AlwatrStore {
    */
   async openCollection<TItem extends JsonifiableObject>(id: StoreFileId): Promise<CollectionReference<TItem>> {
     const id_ = getStoreId(id);
-    logger.logMethodArgs?.('collection', id_);
+    logger.logMethodArgs?.('openCollection', id_);
 
     // try to get from cache
     if (Object.hasOwn(this.cacheReferences__, id_)) {

--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -204,10 +204,10 @@ export class AlwatrStore {
 
     let fileStoreRef: DocumentReference | CollectionReference;
     if (stat.type === StoreFileType.Document) {
-      fileStoreRef = DocumentReference.newRefFromData(stat, initialData as DocumentContext['data'], this.storeChanged__.bind(this));
+      fileStoreRef = DocumentReference.newRefFromData(stat, initialData as DocumentContext['data'], this.storeChanged_.bind(this));
     }
     else if (stat.type === StoreFileType.Collection) {
-      fileStoreRef = CollectionReference.newRefFromData(stat, initialData as CollectionContext['data'], this.storeChanged__.bind(this));
+      fileStoreRef = CollectionReference.newRefFromData(stat, initialData as CollectionContext['data'], this.storeChanged_.bind(this));
     }
     else {
       logger.accident('newStoreFile_', 'store_file_type_not_supported', stat);
@@ -223,7 +223,7 @@ export class AlwatrStore {
     this.cacheReferences__[fileStoreRef.id] = fileStoreRef;
 
     // fileStoreRef.save();
-    this.storeChanged__(fileStoreRef);
+    this.storeChanged_(fileStoreRef);
   }
 
   /**
@@ -269,7 +269,7 @@ export class AlwatrStore {
     }
 
     const context = await this.readContext__<DocumentContext<TDoc>>(storeStat);
-    const docRef = DocumentReference.newRefFromContext(context, this.storeChanged__.bind(this));
+    const docRef = DocumentReference.newRefFromContext(context, this.storeChanged_.bind(this));
     this.cacheReferences__[id_] = docRef as unknown as DocumentReference;
     return docRef;
   }
@@ -319,7 +319,7 @@ export class AlwatrStore {
     }
 
     const context = await this.readContext__<CollectionContext<TItem>>(storeStat);
-    const colRef = CollectionReference.newRefFromContext(context, this.storeChanged__.bind(this));
+    const colRef = CollectionReference.newRefFromContext(context, this.storeChanged_.bind(this));
     this.cacheReferences__[id_] = colRef as unknown as CollectionReference;
     return colRef;
   }
@@ -341,7 +341,7 @@ export class AlwatrStore {
     if (ref === undefined) return;
     if (ref.hasUnprocessedChanges_ === true) {
       ref.updateDelayed_ = false;
-      this.storeChanged__(ref);
+      this.storeChanged_(ref);
     }
     delete this.cacheReferences__[id_];
   }
@@ -398,7 +398,7 @@ export class AlwatrStore {
     for (const ref of Object.values(this.cacheReferences__)) {
       if (ref.hasUnprocessedChanges_ === true && ref.freeze !== true) {
         ref.updateDelayed_ = false;
-        await this.storeChanged__(ref);
+        await this.storeChanged_(ref);
       }
     }
   }
@@ -442,7 +442,7 @@ export class AlwatrStore {
    * @param context The store file context. If not provided, it will be loaded from memory.
    * @param sync If true, the file will be written synchronously.
    */
-  protected async storeChanged__<T extends JsonifiableObject>(from: DocumentReference<T> | CollectionReference<T>): Promise<void> {
+  protected async storeChanged_<T extends JsonifiableObject>(from: DocumentReference<T> | CollectionReference<T>): Promise<void> {
     logger.logMethodArgs?.('storeChanged__', from.id);
     const rev = from.meta().rev;
     try {
@@ -469,11 +469,11 @@ export class AlwatrStore {
       }
 
       logger.banner('Initialize new alwatr-store');
-      return CollectionReference.newRefFromData(AlwatrStore.rootDbStat__, null, this.storeChanged__.bind(this));
+      return CollectionReference.newRefFromData(AlwatrStore.rootDbStat__, null, this.storeChanged_.bind(this));
     }
     // else
     const context = readJson<CollectionContext<StoreFileStat>>(fullPath, true);
-    return CollectionReference.newRefFromContext(context, this.storeChanged__.bind(this), 'root-db');
+    return CollectionReference.newRefFromContext(context, this.storeChanged_.bind(this), 'root-db');
   }
 
   /**

--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -347,21 +347,22 @@ export class AlwatrStore {
   }
 
   /**
-   * Deletes a file from the store.
-   *
+   * Remove document or collection from store and delete the file from disk.
+   * If the file is not found, an error is thrown.
+   * If the file is not unloaded, it will be unloaded first.
    * You don't need to await this method to complete unless you want to make sure the file is deleted on disk.
    *
    * @param id_ The ID of the file to delete.
    * @returns A Promise that resolves when the file is deleted.
    * @example
    * ```typescript
-   * alwatrStore.deleteFile({name: 'user-list', region: Region.Secret});
-   * alwatrStore.exists({name: 'user-list', region: Region.Secret}); // true
+   * alwatrStore.remove({name: 'user-list', region: Region.Secret});
+   * alwatrStore.exists({name: 'user-list', region: Region.Secret}); // false
    * ```
    */
-  async deleteFile(id: StoreFileId): Promise<void> {
+  async remove(id: StoreFileId): Promise<void> {
     const id_ = getStoreId(id);
-    logger.logMethodArgs?.('deleteFile', id_);
+    logger.logMethodArgs?.('remove', id_);
     if (!this.rootDb__.exists(id_)) {
       logger.accident('doc', 'document_not_found', id_);
       throw new Error('document_not_found', {cause: id_});
@@ -380,7 +381,7 @@ export class AlwatrStore {
       await unlink(resolve(this.config__.rootPath, path));
     }
     catch (error) {
-      logger.error('deleteFile', 'delete_file_failed', {id: id_, path, error});
+      logger.error('deleteFile', 'remove_file_failed', error, {id, path});
     }
   }
 

--- a/packages/engine/src/alwatr-store.ts
+++ b/packages/engine/src/alwatr-store.ts
@@ -210,12 +210,12 @@ export class AlwatrStore {
       fileStoreRef = CollectionReference.newRefFromData(stat, initialData as CollectionContext['data'], this.storeChanged__.bind(this));
     }
     else {
-      logger.accident('defineDocument', 'store_file_type_not_supported', stat);
+      logger.accident('newStoreFile_', 'store_file_type_not_supported', stat);
       throw new Error('store_file_type_not_supported', {cause: stat});
     }
 
     if (this.rootDb__.exists(fileStoreRef.id)) {
-      logger.accident('defineDocument', 'store_file_already_defined', stat);
+      logger.accident('newStoreFile_', 'store_file_already_defined', stat);
       throw new Error('store_file_already_defined', {cause: stat});
     }
 
@@ -250,21 +250,21 @@ export class AlwatrStore {
     if (Object.hasOwn(this.cacheReferences__, id_)) {
       const ref = this.cacheReferences__[id_];
       if (!(ref instanceof DocumentReference)) {
-        logger.accident('doc', 'document_wrong_type', id_);
+        logger.accident('openDocument', 'document_wrong_type', id_);
         throw new Error('document_wrong_type', {cause: id_});
       }
       return this.cacheReferences__[id_] as unknown as DocumentReference<TDoc>;
     }
 
     if (!this.rootDb__.exists(id_)) {
-      logger.accident('doc', 'document_not_found', id_);
+      logger.accident('openDocument', 'document_not_found', id_);
       throw new Error('document_not_found', {cause: id_});
     }
 
     const storeStat = this.rootDb__.get(id_);
 
     if (storeStat.type != StoreFileType.Document) {
-      logger.accident('doc', 'document_wrong_type', id_);
+      logger.accident('openDocument', 'document_wrong_type', id_);
       throw new Error('document_wrong_type', {cause: id_});
     }
 
@@ -299,7 +299,7 @@ export class AlwatrStore {
     if (Object.hasOwn(this.cacheReferences__, id_)) {
       const ref = this.cacheReferences__[id_];
       if (!(ref instanceof CollectionReference)) {
-        logger.accident('collection', 'collection_wrong_type', id_);
+        logger.accident('openCollection', 'collection_wrong_type', id_);
         throw new Error('collection_wrong_type', {cause: id_});
       }
       return this.cacheReferences__[id_] as unknown as CollectionReference<TItem>;
@@ -307,14 +307,14 @@ export class AlwatrStore {
 
     // load and create new collection reference
     if (!this.rootDb__.exists(id_)) {
-      logger.accident('collection', 'collection_not_found', id_);
+      logger.accident('openCollection', 'collection_not_found', id_);
       throw new Error('collection_not_found', {cause: id_});
     }
 
     const storeStat = this.rootDb__.get(id_);
 
     if (storeStat.type != StoreFileType.Collection) {
-      logger.accident('doc', 'collection_wrong_type', id_);
+      logger.accident('openCollection', 'collection_wrong_type', id_);
       throw new Error('collection_not_found', {cause: id_});
     }
 

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -22,9 +22,9 @@
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/main.mjs",
-      "require": "./dist/main.cjs",
-      "types": "./dist/main.d.ts"
+      "require": "./dist/main.cjs"
     }
   },
   "license": "MIT",
@@ -60,10 +60,10 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/flat-string": "^1.0.20",
-    "@alwatr/logger": "^3.2.11",
+    "@alwatr/flat-string": "^1.0.21",
+    "@alwatr/logger": "^3.2.12",
     "@alwatr/store-types": "workspace:^",
-    "@alwatr/wait": "^1.1.13"
+    "@alwatr/wait": "^1.1.14"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^1.3.8",

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -308,12 +308,16 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Retrieves an item's metadata from the collection. If the item does not exist, an error is thrown.
    *
-   * @param id - The ID of the item.
+   * @param itemId - The ID of the item.
    * @returns The metadata of the item with the given ID.
+   * @example
+   * ```typescript
+   * const itemMeta = collectionRef.getItemMetadata('item1');
+   * ```
    */
-  metaItem(id: string | number): Readonly<CollectionItemMeta> {
-    const meta = this.item__(id).meta;
-    this.logger__.logMethodFull?.('meta', id, meta);
+  getItemMetadata(itemId: string | number): Readonly<CollectionItemMeta> {
+    const meta = this.item__(itemId).meta;
+    this.logger__.logMethodFull?.('getItemMetadata', itemId, meta);
     return meta;
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -426,18 +426,18 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Sets an item's data in the collection. Replaces the item's data with the given data.
    *
-   * @param id - The ID of the item to set.
+   * @param itemId - The ID of the item to set.
    * @param data - The data to set for the item.
    *
    * @example
    * ```typescript
-   * collectionRef.set('item1', { key: 'new value' });
+   * collectionRef.update('item1', { a: 1, b: 2, c: 3 });
    * ```
    */
-  set(id: string | number, data: TItem): void {
-    this.logger__.logMethodArgs?.('set', {id, data});
-    (this.item__(id).data as unknown) = data;
-    this.updated__(id);
+  update(itemId: string | number, data: TItem): void {
+    this.logger__.logMethodArgs?.('update', {itemId, data});
+    (this.item__(itemId).data as unknown) = data;
+    this.updated__(itemId);
   }
 
   /**

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -408,18 +408,18 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   }
 
   /**
-   * Deletes an item from the collection.
+   * Removes an item from the collection.
    *
-   * @param id - The ID of the item to delete.
+   * @param itemId - The ID of the item to delete.
    *
    * @example
    * ```typescript
-   * collectionRef.delete('item1');
+   * collectionRef.remove('item1');
    * ```
    */
-  delete(id: string | number): void {
-    this.logger__.logMethodArgs?.('delete', id);
-    delete this.context__.data[id];
+  remove(itemId: string | number): void {
+    this.logger__.logMethodArgs?.('remove', itemId);
+    delete this.context__.data[itemId];
     this.updated__(null);
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -324,17 +324,17 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Retrieves an item's data from the collection. If the item does not exist, an error is thrown.
    *
-   * @param id - The ID of the item.
+   * @param itemId - The ID of the item.
    * @returns The data of the item with the given ID.
    *
    * @example
    * ```typescript
-   * const itemData = collectionRef.get('item1');
+   * const itemData = collectionRef.getItem('item1');
    * ```
    */
-  get(id: string | number): TItem {
-    this.logger__.logMethodArgs?.('get', id);
-    return this.item__(id).data;
+  getItem(itemId: string | number): TItem {
+    this.logger__.logMethodArgs?.('get', itemId);
+    return this.item__(itemId).data;
   }
 
   /**

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -441,20 +441,20 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   }
 
   /**
-   * Updates an item in the collection. Can be used to update a part of the item.
+   * Updates an item in the collection by merging a partial update into the item's data.
    *
-   * @param id - The ID of the item to update.
-   * @param data - The data to update for the item.
+   * @param itemId - The ID of the item to update.
+   * @param data - The part of data to merge into the item's data.
    *
    * @example
    * ```typescript
-   * collectionRef.update('item1', { key: 'updated value' });
+   * collectionRef.updatePartial(itemId, partialUpdate);
    * ```
    */
-  update(id: string | number, data: Partial<TItem>): void {
-    this.logger__.logMethodArgs?.('update', {id, data});
-    Object.assign(this.item__(id).data, data);
-    this.updated__(id);
+  updatePartial(itemId: string | number, data: Partial<TItem>): void {
+    this.logger__.logMethodArgs?.('updatePartial', {itemId, data});
+    Object.assign(this.item__(itemId).data, data);
+    this.updated__(itemId);
   }
 
   /**

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -606,15 +606,15 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Updates the collection's metadata.
    *
-   * @param id - The ID of the item to update.
+   * @param itemId - The ID of the item to update.
    */
-  updateMeta_(id: string | number | null): void {
-    this.logger__.logMethodArgs?.('updateMeta__', {id});
+  updateMetadata_(itemId: string | number | null): void {
+    this.logger__.logMethodArgs?.('updateMetadata_', {id: itemId});
     const now = Date.now();
     this.context__.meta.rev++;
     this.context__.meta.updated = now;
-    if (id !== null) {
-      const itemMeta = this.item__(id).meta;
+    if (itemId !== null) {
+      const itemMeta = this.item__(itemId).meta;
       itemMeta.rev++;
       itemMeta.updated = now;
     }

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -342,17 +342,17 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    * If the item does not exist, `undefined` is returned.
    * **USE WITH CAUTION!**
    *
-   * @param id - The ID of the item.
+   * @param itemId - The ID of the item.
    * @returns The data of the item with the given ID or `undefined` if the item does not exist.
    *
    * @example
    * ```typescript
-   * collectionRef.access_('item1')?.data.name = 'test2';
+   * collectionRef.getItemContext_('item1')?.data.name = 'test2';
    * ```
    */
-  access_(id: string | number): CollectionItem<TItem> | undefined {
-    this.logger__.logMethodArgs?.('access_', id);
-    return this.context__.data[id];
+  getItemContext_(itemId: string | number): CollectionItem<TItem> | undefined {
+    this.logger__.logMethodArgs?.('access_', itemId);
+    return this.context__.data[itemId];
   }
 
   /**

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -282,11 +282,11 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    *
    * @example
    * ```typescript
-   * const metadata = collectionRef.meta();
+   * const metadata = collectionRef.getStoreMetadata();
    * ```
    */
-  meta(): Readonly<StoreFileMeta> {
-    this.logger__.logMethod?.('meta');
+  getStoreMetadata(): Readonly<StoreFileMeta> {
+    this.logger__.logMethod?.('getCollectionMetadata');
     return this.context__.meta;
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -286,7 +286,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    * ```
    */
   getStoreMetadata(): Readonly<StoreFileMeta> {
-    this.logger__.logMethod?.('getCollectionMetadata');
+    this.logger__.logMethod?.('getStoreMetadata');
     return this.context__.meta;
   }
 
@@ -333,7 +333,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    * ```
    */
   getItem(itemId: string | number): TItem {
-    this.logger__.logMethodArgs?.('get', itemId);
+    this.logger__.logMethodArgs?.('getItem', itemId);
     return this.item__(itemId).data;
   }
 
@@ -351,7 +351,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    * ```
    */
   getItemContext_(itemId: string | number): CollectionItem<TItem> | undefined {
-    this.logger__.logMethodArgs?.('access_', itemId);
+    this.logger__.logMethodArgs?.('getItemContext_', itemId);
     return this.context__.data[itemId];
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -356,28 +356,29 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   }
 
   /**
-   * Creates a new item in the collection. If an item with the given ID already exists, an error is thrown.
+   * Add a new item to the collection.
+   * If an item with the given ID already exists, an error is thrown.
    *
-   * @param id - The ID of the item to create.
+   * @param itemId - The ID of the item to create.
    * @param data - The initial data of the item.
    *
    * @example
    * ```typescript
-   * collectionRef.create('item1', { key: 'value' });
+   * collectionRef.add('item1', { key: 'value' });
    * ```
    */
-  create(id: string | number, data: TItem): void {
-    this.logger__.logMethodArgs?.('create', {id, data});
-    if (this.exists(id)) {
-      this.logger__.accident('create', 'collection_item_exist', {id});
-      throw new Error('collection_item_exist', {cause: {id}});
+  add(itemId: string | number, data: TItem): void {
+    this.logger__.logMethodArgs?.('add', {itemId, data});
+    if (this.exists(itemId)) {
+      this.logger__.accident('add', 'collection_item_exist', {itemId});
+      throw new Error('collection_item_exist', {cause: {itemId}});
     }
 
     const now = Date.now();
 
-    this.context__.data[id] = {
+    this.context__.data[itemId] = {
       meta: {
-        id,
+        id: itemId,
         // other prop calc in updateMeta__
         rev: 0,
         created: now,
@@ -385,7 +386,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
       },
       data,
     };
-    this.updated__(id);
+    this.updated__(itemId);
   }
 
   /**

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -257,7 +257,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Checks if an item exists in the collection.
    *
-   * @param id - The ID of the item.
+   * @param itemId - The ID of the item.
    * @returns `true` if the item with the given ID exists in the collection, `false` otherwise.
    *
    * @example
@@ -269,9 +269,9 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
    * }
    * ```
    */
-  exists(id: string | number): boolean {
-    const exists = Object.hasOwn(this.context__.data, id);
-    this.logger__.logMethodFull?.('exists', id, exists);
+  exists(itemId: string | number): boolean {
+    const exists = Object.hasOwn(this.context__.data, itemId);
+    this.logger__.logMethodFull?.('exists', itemId, exists);
     return exists;
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -293,14 +293,14 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   /**
    * Retrieves an item from the collection. If the item does not exist, an error is thrown.
    *
-   * @param id - The ID of the item.
+   * @param itemId - The ID of the item.
    * @returns The item with the given ID.
    */
-  private item__(id: string | number): CollectionItem<TItem> {
-    const item = this.context__.data[id];
+  private item__(itemId: string | number): CollectionItem<TItem> {
+    const item = this.context__.data[itemId];
     if (item === undefined) {
-      this.logger__.accident('item_', 'collection_item_not_found', {id});
-      throw new Error('collection_item_not_found', {cause: {id}});
+      this.logger__.accident('item_', 'collection_item_not_found', {itemId});
+      throw new Error('collection_item_not_found', {cause: {itemId}});
     }
     return item;
   }
@@ -403,7 +403,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
   append(data: TItem): string | number {
     this.logger__.logMethodArgs?.('append', data);
     const id = this.nextAutoIncrementId__();
-    this.create(id, data);
+    this.add(id, data);
     return id;
   }
 
@@ -580,7 +580,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
     this.logger__.logMethodArgs?.('updated__', {id, immediate, delayed: this.updateDelayed_});
 
     this.hasUnprocessedChanges_ = true;
-    if (id !== null) this.updateMeta_(id); // meta must updated per item
+    if (id !== null) this.updateMetadata_(id); // meta must updated per item
 
     if (immediate === false && this.updateDelayed_ === true) return;
     // else
@@ -597,7 +597,7 @@ export class CollectionReference<TItem extends JsonifiableObject = JsonifiableOb
     if (this.updateDelayed_ !== true) return; // another parallel update finished!
     this.updateDelayed_ = false;
 
-    if (id === null) this.updateMeta_(id); // root meta not updated for null
+    if (id === null) this.updateMetadata_(id); // root meta not updated for null
 
     if (this._freeze === true) return; // prevent save if frozen
     this.updatedCallback__.call(null, this);

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -285,18 +285,17 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
   }
 
   /**
-   * Update Document's data.
-   * Can be used to update a part of the document.
+   * Updates document's data by merging a partial update into the document's data.
    *
-   * @param data Data to update the document with.
+   * @param data The part of data to merge into the document's data.
    *
    * @example
    * ```typescript
-   * documentRef.update({ key: 'updated value' });
+   * documentRef.updatePartial({ c: 4 });
    * ```
    */
-  update(data: Partial<TDoc>): void {
-    this.logger__.logMethodArgs?.('update', data);
+  updatePartial(data: Partial<TDoc>): void {
+    this.logger__.logMethodArgs?.('updatePartial', data);
     Object.assign(this.context__.data, data);
     this.updated__();
   }

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -245,11 +245,11 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
    *
    * @example
    * ```typescript
-   * const documentData = documentRef.get();
+   * const documentData = documentRef.getData();
    * ```
    */
-  get(): TDoc {
-    this.logger__.logMethod?.('get');
+  getData(): TDoc {
+    this.logger__.logMethod?.('getData');
     return this.context__.data;
   }
 

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -260,11 +260,11 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
    *
    * @example
    * ```typescript
-   * const documentMeta = documentRef.meta();
+   * const documentMeta = documentRef.gerStoreMetadata();
    * ```
    */
-  meta(): Readonly<StoreFileMeta> {
-    this.logger__.logMethod?.('meta');
+  getStoreMetadata(): Readonly<StoreFileMeta> {
+    this.logger__.logMethod?.('documentMetadata');
     return this.context__.meta;
   }
 

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -264,7 +264,7 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
    * ```
    */
   getStoreMetadata(): Readonly<StoreFileMeta> {
-    this.logger__.logMethod?.('documentMetadata');
+    this.logger__.logMethod?.('getStoreMetadata');
     return this.context__.meta;
   }
 

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -269,17 +269,17 @@ export class DocumentReference<TDoc extends JsonifiableObject = JsonifiableObjec
   }
 
   /**
-   * Sets the document's data.
+   * Sets the document's data. replacing the existing data.
    *
    * @param data The new document data.
    *
    * @example
    * ```typescript
-   * documentRef.set({ key: 'value' });
+   * documentRef.update({ a: 1, b: 2, c: 3 });
    * ```
    */
-  set(data: TDoc): void {
-    this.logger__.logMethodArgs?.('set', data);
+  update(data: TDoc): void {
+    this.logger__.logMethodArgs?.('update', data);
     (this.context__.data as unknown) = data;
     this.updated__();
   }

--- a/packages/reference/src/util.ts
+++ b/packages/reference/src/util.ts
@@ -1,5 +1,5 @@
 import {flatString} from '@alwatr/flat-string';
-import {type StoreFileId, type StoreFileStat} from '@alwatr/store-types';
+import {StoreFileExtension, type StoreFileId, type StoreFileStat} from '@alwatr/store-types';
 
 /**
  * Convert StoreFileId to a string ID.
@@ -26,6 +26,6 @@ export function getStorePath(storeStat: StoreFileStat): string {
   if (storeStat.ownerId !== undefined) {
     path += '/' + storeStat.ownerId.slice(0, 3) + '/' + storeStat.ownerId;
   }
-  path += `/${storeStat.name}.${storeStat.type}.${storeStat.extension}`;
+  path += `/${storeStat.name}.${storeStat.type}.${storeStat.extension ?? StoreFileExtension.Json}`;
   return flatString(path);
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,9 +22,9 @@
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/main.mjs",
-      "require": "./dist/main.cjs",
-      "types": "./dist/main.d.ts"
+      "require": "./dist/main.cjs"
     }
   },
   "license": "MIT",
@@ -60,7 +60,7 @@
     "clean": "rm -rfv dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@alwatr/dedupe": "^1.0.11"
+    "@alwatr/dedupe": "^1.0.12"
   },
   "devDependencies": {
     "@alwatr/nano-build": "^1.3.8",

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -114,7 +114,7 @@ export type StoreFileStat = StoreFileId & {
    *
    * @see {@link StoreFileExtension}
    */
-  readonly extension: StoreFileExtension;
+  readonly extension?: StoreFileExtension;
 
   /**
    * The save debounce timeout in milliseconds for minimal disk I/O usage.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,19 +5,19 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@alwatr/async-queue@npm:^1.2.8":
-  version: 1.2.8
-  resolution: "@alwatr/async-queue@npm:1.2.8"
+"@alwatr/async-queue@npm:^1.2.9":
+  version: 1.2.9
+  resolution: "@alwatr/async-queue@npm:1.2.9"
   dependencies:
-    "@alwatr/flatomise": "npm:^1.1.9"
-  checksum: 10c0/029f0d92eaf737060ed40e67d3f15d6588e9ea3cf020cea8d8ed2c4c65e80a0e2ce46166043348735489fe32feba5a523d8e31b842feec090d1e6c2738c3f787
+    "@alwatr/flatomise": "npm:^1.1.10"
+  checksum: 10c0/a1b9e5e2612f748b146ce524c196a71960c1ff80cd84db45c1f046a2645fe55610f1057a77f349083cbe34a294381c83f70bda3bf385ac6b605732be11fe1908
   languageName: node
   linkType: hard
 
-"@alwatr/dedupe@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "@alwatr/dedupe@npm:1.0.11"
-  checksum: 10c0/5a5f37c1251c70f1e07b33b9362b6912ec76a635475b9c3a0b3d4e25ab50d74dc0593341052d7ba0c85dfc01377829f00cf82229805b91de6040380f5000ab38
+"@alwatr/dedupe@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "@alwatr/dedupe@npm:1.0.12"
+  checksum: 10c0/b2ac59809e7c568260a14d898ec4167bb52d5967fbccfe9a9b02b8512919d464b2e20872addad0beff7f8505e1dd343e57649f69ff8b0595541d0cb4956991d4
   languageName: node
   linkType: hard
 
@@ -37,43 +37,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/exit-hook@npm:^1.0.13":
-  version: 1.0.13
-  resolution: "@alwatr/exit-hook@npm:1.0.13"
+"@alwatr/exit-hook@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@alwatr/exit-hook@npm:1.0.14"
   dependencies:
-    "@alwatr/dedupe": "npm:^1.0.11"
-  checksum: 10c0/9b12b8520a7651521ad6eff5b6b8e0c6e9f33c244610aa340466a3bb0b9d8da5bf0d20e2b91a7b20de831c02813fea140ef1f091787a43c340354898489062c0
+    "@alwatr/dedupe": "npm:^1.0.12"
+  checksum: 10c0/8d227f4294523bbca3575096a0a9731e3d45dce65c0db2f656c9c89020e1821b6223589da77ff0033c58a96c7c7dea5d60f4edd9c7a016c86a744fa7c49eaa44
   languageName: node
   linkType: hard
 
-"@alwatr/flat-string@npm:^1.0.20":
-  version: 1.0.20
-  resolution: "@alwatr/flat-string@npm:1.0.20"
-  checksum: 10c0/83147b3260a4e81f847de520b82d15fbcea57bfa8d11f5d07fe01fccf0aee6c6a1bedae42ad641839a162fedefd470fc82c598aea2175d92ab98ff23f3378972
+"@alwatr/flat-string@npm:^1.0.21":
+  version: 1.0.21
+  resolution: "@alwatr/flat-string@npm:1.0.21"
+  checksum: 10c0/8d8066953fcaf21149019b04c7e45638aa1f868d1c4c5081b399b3870f5ad392730e468604af5d6b897569dac2e6e7da23509651672f5367a7dde3d35ec151c9
   languageName: node
   linkType: hard
 
-"@alwatr/flatomise@npm:^1.1.9":
-  version: 1.1.9
-  resolution: "@alwatr/flatomise@npm:1.1.9"
-  checksum: 10c0/51647d6a2a8e900bfdf19a214e60a184544a896adaaa2af39873e83e591096b0612ee12fc7afcf8cb780a36b9c5383e6fbd990ddbf07a94fa98c57c903a7420c
+"@alwatr/flatomise@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "@alwatr/flatomise@npm:1.1.10"
+  checksum: 10c0/94e93e8aa80144a8f24ed96a907b4cc759d9234cb77612e2606d2a3f3fc961e5e215363e65633baceb3de83d1b5c612ca64a8d30b689e4dedff2cae7c3dfdc54
   languageName: node
   linkType: hard
 
-"@alwatr/global-scope@npm:^1.1.18":
-  version: 1.1.18
-  resolution: "@alwatr/global-scope@npm:1.1.18"
-  checksum: 10c0/8e3fb5173738c118fb1cc5ca8140fc00d7deddd7f17889c98757e5eb5ce668676988f72e7c587b4729144867c652546038f3a85462f58f2fa0b3c79a2bd8d853
+"@alwatr/global-scope@npm:^1.1.19":
+  version: 1.1.19
+  resolution: "@alwatr/global-scope@npm:1.1.19"
+  checksum: 10c0/36c93e9935b2e24b6062874eed7f0df8064520c488e7fa730b56f264ba5fa8cda172df822d7886e316195b882e36a379af2b52965f79483154985b19b137266a
   languageName: node
   linkType: hard
 
-"@alwatr/logger@npm:^3.2.11":
-  version: 3.2.11
-  resolution: "@alwatr/logger@npm:3.2.11"
+"@alwatr/logger@npm:^3.2.12":
+  version: 3.2.12
+  resolution: "@alwatr/logger@npm:3.2.12"
   dependencies:
-    "@alwatr/dedupe": "npm:^1.0.11"
-    "@alwatr/platform-info": "npm:^1.1.10"
-  checksum: 10c0/ba3c9c561b24de0c35e26a58ea7d379acfef33c0de3e95ace3b74821182192de8231b69e32b208606afd7a8b3e980de8cbe8b5d15945d3d50fe7a77578caa078
+    "@alwatr/dedupe": "npm:^1.0.12"
+    "@alwatr/platform-info": "npm:^1.1.11"
+  checksum: 10c0/4445ea4ad025091c9bf6a1d07878d3d48fa1721137a03d79ad543ae9a2218b7ad68c77d855310733ab196b59f065cf547fd6d3281a097bbfa9dc430a78494c60
   languageName: node
   linkType: hard
 
@@ -88,21 +88,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/node-fs@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "@alwatr/node-fs@npm:1.0.10"
+"@alwatr/node-fs@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@alwatr/node-fs@npm:1.0.11"
   dependencies:
-    "@alwatr/async-queue": "npm:^1.2.8"
-    "@alwatr/flat-string": "npm:^1.0.20"
-    "@alwatr/logger": "npm:^3.2.11"
-  checksum: 10c0/513ff2f1f482d355c3c4306c711a074f46742cdece189e252655f2f1de1874c1564982e3df5c8736c7f4ca4450382e204709bca601ef84824b3da85e2b6aa4da
+    "@alwatr/async-queue": "npm:^1.2.9"
+    "@alwatr/flat-string": "npm:^1.0.21"
+    "@alwatr/logger": "npm:^3.2.12"
+  checksum: 10c0/46bc64a14208e9322bbf850ce840176dd9beff741a465c9219061d6c446f698c8a2b6216a4dfd666fa95c321a4fb83053b4237fd1dfbe948454870563904bf1c
   languageName: node
   linkType: hard
 
-"@alwatr/platform-info@npm:^1.1.10":
-  version: 1.1.10
-  resolution: "@alwatr/platform-info@npm:1.1.10"
-  checksum: 10c0/55d2b8c1a22f2f9b08b78c9a909916dd3bf5439f61f88a129f3b7a89dec731924a36bec74361a76c5795c20727efd00890ee7e2b32ee20140e69121fbd418db6
+"@alwatr/platform-info@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "@alwatr/platform-info@npm:1.1.11"
+  checksum: 10c0/9c04a76459f31b1bbac37f2ae802554a9af593f9037e3b1fa6254d2ff5de3bf0e2cb81545fb57e7550173433f2cacaddb1f391fb6452c1df6d0f9c3ca1440228
   languageName: node
   linkType: hard
 
@@ -117,17 +117,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/store-engine@workspace:packages/engine"
   dependencies:
-    "@alwatr/exit-hook": "npm:^1.0.13"
-    "@alwatr/flat-string": "npm:^1.0.20"
-    "@alwatr/logger": "npm:^3.2.11"
+    "@alwatr/exit-hook": "npm:^1.0.14"
+    "@alwatr/flat-string": "npm:^1.0.21"
+    "@alwatr/logger": "npm:^3.2.12"
     "@alwatr/nano-build": "npm:^1.3.8"
-    "@alwatr/node-fs": "npm:^1.0.10"
+    "@alwatr/node-fs": "npm:^1.0.11"
     "@alwatr/prettier-config": "npm:^1.0.4"
     "@alwatr/store-reference": "workspace:^"
     "@alwatr/store-types": "workspace:^"
     "@alwatr/tsconfig-base": "npm:^1.2.0"
     "@alwatr/type-helper": "npm:^1.2.5"
-    "@alwatr/wait": "npm:^1.1.13"
+    "@alwatr/wait": "npm:^1.1.14"
     "@types/node": "npm:^22.5.1"
     typescript: "npm:^5.5.4"
   languageName: unknown
@@ -143,14 +143,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/store-reference@workspace:packages/reference"
   dependencies:
-    "@alwatr/flat-string": "npm:^1.0.20"
-    "@alwatr/logger": "npm:^3.2.11"
+    "@alwatr/flat-string": "npm:^1.0.21"
+    "@alwatr/logger": "npm:^3.2.12"
     "@alwatr/nano-build": "npm:^1.3.8"
     "@alwatr/prettier-config": "npm:^1.0.4"
     "@alwatr/store-types": "workspace:^"
     "@alwatr/tsconfig-base": "npm:^1.2.0"
     "@alwatr/type-helper": "npm:^1.2.5"
-    "@alwatr/wait": "npm:^1.1.13"
+    "@alwatr/wait": "npm:^1.1.14"
     "@types/node": "npm:^22.5.1"
     typescript: "npm:^5.5.4"
   languageName: unknown
@@ -160,7 +160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr/store-types@workspace:packages/types"
   dependencies:
-    "@alwatr/dedupe": "npm:^1.0.11"
+    "@alwatr/dedupe": "npm:^1.0.12"
     "@alwatr/nano-build": "npm:^1.3.8"
     "@alwatr/prettier-config": "npm:^1.0.4"
     "@alwatr/tsconfig-base": "npm:^1.2.0"
@@ -184,12 +184,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alwatr/wait@npm:^1.1.13":
-  version: 1.1.13
-  resolution: "@alwatr/wait@npm:1.1.13"
+"@alwatr/wait@npm:^1.1.14":
+  version: 1.1.14
+  resolution: "@alwatr/wait@npm:1.1.14"
   dependencies:
-    "@alwatr/global-scope": "npm:^1.1.18"
-  checksum: 10c0/84703c4b597a2d4b89251f36b72facbeae059d90873be8fc4cac589ac3d681b8a2c4c4cb874fe4c1f32c62182ccc4f41e81dc16ac8272aa97d71da53ee45dfdc
+    "@alwatr/global-scope": "npm:^1.1.19"
+  checksum: 10c0/693e6497c6d204e5007ea1b5fac90df7f298391eca108f625c8b1590a4aaddef222e9d85c1e2b1ef3f71b3bdfd89931e87c07940b9d5fec6cec6067bc34dd698
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **refactor: update StoreFileStat type to make extension property optional**
- **feat: Add newDocument and newCollection methods to AlwatrStore**
- **feat: Open document and collection with given id in AlwatrStore**
- **fix(alwatr-store): logger methods name issue**
- **refactor: rename `deleteFile` method to `remove`**
- **chore: fix logs messages**
- **refactor: updates the `storeChanged__` method name to `storeChanged_`.**
- **deps: update**
- **refactor: update parameter name in CollectionReference.exists method**
- **feat: Rename `meta` method to `getStoreMetadata` in CollectionReference**
- **refactor(CollectionReference): Rename `metaItem` method to `getItemMetadata` in CollectionReference**
- **refactor: Rename `get` method to `getItem` in CollectionReference**
- **refactor: Rename `access_` method to `getItemContext_`**
- **refactor: Rename `create` method to `add` in CollectionReference**
- **refactor: Rename `delete` method to `remove` in CollectionReference**
- **refactor(CollectionReference): Rename `set` method to `update` in CollectionReference**
- **refactor(CollectionReference): Rename `update` method to `updatePartial` in CollectionReference**
- **refactor(CollectionReference): Rename `updateMeta_` method to `updateMetadata_` in CollectionReference**
- **refactor(DocumentReference): Rename `get` method to `getData` in DocumentReference**
- **refactor(DocumentReference): Rename `meta` method to `getStoreMetadata` in DocumentReference**
- **refactor(DocumentReference): Rename `set` method to `update` in DocumentReference**
- **refactor: Rename `update` method to `updatePartial` in DocumentReference**
- **refactor(CollectionReference): Rename `item__` method parameter from `id` to `itemId`**
- **refactor(AlwatrStore): compatible with new api**
- **refactor(demo): compatible with new api**
- **fix: logger method name in CollectionReference and DocumentReference**
- **refactor: Remove unnecessary debug flag from yarn script**
