### PR TITLE
fix/newDoc

### DIFF
--- a/packages/engine/src/alwatr-nitrobase.ts
+++ b/packages/engine/src/alwatr-nitrobase.ts
@@ -95,6 +95,7 @@ export class AlwatrNitrobase {
     logger.logMethodArgs?.('new', config);
     this.config.defaultChangeDebounce ??= 40;
     this.rootDb__ = this.loadRootDb__();
+    this.storeChanged_ = this.storeChanged_.bind(this);
     exitHook(this.exitHook__.bind(this));
   }
 
@@ -196,10 +197,10 @@ export class AlwatrNitrobase {
         logger.accident('newStoreFile_', 'document_data_required', stat);
         throw new Error('document_data_required', {cause: stat});
       }
-      fileStoreRef = DocumentReference.newRefFromData(stat, data, this.storeChanged_.bind(this));
+      fileStoreRef = DocumentReference.newRefFromData(stat, data, this.storeChanged_);
     }
     else if (stat.type === StoreFileType.Collection) {
-      fileStoreRef = CollectionReference.newRefFromData(stat, this.storeChanged_.bind(this));
+      fileStoreRef = CollectionReference.newRefFromData(stat, this.storeChanged_);
     }
     else {
       logger.accident('newStoreFile_', 'store_file_type_not_supported', stat);
@@ -261,7 +262,7 @@ export class AlwatrNitrobase {
     }
 
     const context = await this.readContext__<DocumentContext<TDoc>>(storeStat);
-    const docRef = DocumentReference.newRefFromContext(context, this.storeChanged_.bind(this));
+    const docRef = DocumentReference.newRefFromContext(context, this.storeChanged_);
     this.cacheReferences__[id] = docRef as unknown as DocumentReference;
     return docRef;
   }
@@ -311,7 +312,7 @@ export class AlwatrNitrobase {
     }
 
     const context = await this.readContext__<CollectionContext<TItem>>(storeStat);
-    const colRef = CollectionReference.newRefFromContext(context, this.storeChanged_.bind(this));
+    const colRef = CollectionReference.newRefFromContext(context, this.storeChanged_);
     this.cacheReferences__[id] = colRef as unknown as CollectionReference;
     return colRef;
   }
@@ -460,11 +461,11 @@ export class AlwatrNitrobase {
       }
 
       logger.banner('Initialize new alwatr-nitrobase');
-      return CollectionReference.newRefFromData(AlwatrNitrobase.rootDbStat__, null, this.storeChanged_.bind(this));
+      return CollectionReference.newRefFromData(AlwatrNitrobase.rootDbStat__, this.storeChanged_);
     }
     // else
     const context = readJson<CollectionContext<StoreFileStat>>(fullPath, true);
-    return CollectionReference.newRefFromContext(context, this.storeChanged_.bind(this), 'root-db');
+    return CollectionReference.newRefFromContext(context, this.storeChanged_, 'root-db');
   }
 
   /**

--- a/packages/engine/src/alwatr-nitrobase.ts
+++ b/packages/engine/src/alwatr-nitrobase.ts
@@ -122,7 +122,7 @@ export class AlwatrNitrobase {
    * If a document with the same ID already exists, an error is thrown.
    *
    * @param stat nitrobase file stat
-   * @param initialData initial data for the document
+   * @param data initial data for the document
    * @template TDoc document data type
    * @example
    * ```typescript
@@ -180,12 +180,11 @@ export class AlwatrNitrobase {
    * Defines a AlwatrNitrobaseFile with the given configuration and initial data.
    *
    * @param stat nitrobase file stat
-   * @param initialData initial data for the document
-   * @template TDoc document data type
+   * @param data initial data for the document
    */
-  newStoreFile_<T extends JsonObject = JsonObject>(
+  newStoreFile_(
     stat: StoreFileStat,
-    initialData: DocumentContext<T>['data'] | CollectionContext<T>['data'] | null = null,
+    data?: DictionaryOpt,
   ): void {
     logger.logMethodArgs?.('newStoreFile_', stat);
 
@@ -193,10 +192,14 @@ export class AlwatrNitrobase {
 
     let fileStoreRef: DocumentReference | CollectionReference;
     if (stat.type === StoreFileType.Document) {
-      fileStoreRef = DocumentReference.newRefFromData(stat, initialData as DocumentContext['data'], this.storeChanged_.bind(this));
+      if (data === undefined) {
+        logger.accident('newStoreFile_', 'document_data_required', stat);
+        throw new Error('document_data_required', {cause: stat});
+      }
+      fileStoreRef = DocumentReference.newRefFromData(stat, data, this.storeChanged_.bind(this));
     }
     else if (stat.type === StoreFileType.Collection) {
-      fileStoreRef = CollectionReference.newRefFromData(stat, initialData as CollectionContext['data'], this.storeChanged_.bind(this));
+      fileStoreRef = CollectionReference.newRefFromData(stat, this.storeChanged_.bind(this));
     }
     else {
       logger.accident('newStoreFile_', 'store_file_type_not_supported', stat);

--- a/packages/engine/src/alwatr-nitrobase.ts
+++ b/packages/engine/src/alwatr-nitrobase.ts
@@ -155,8 +155,6 @@ export class AlwatrNitrobase {
    * If a collection with the same ID already exists, an error is thrown.
    *
    * @param stat nitrobase file stat
-   * @param initialData initial data for the collection
-   * @template TItem collection item data type
    * @example
    * ```typescript
    * await alwatrStore.newCollection<Order>(
@@ -168,17 +166,13 @@ export class AlwatrNitrobase {
    * );
    * ```
    */
-  newCollection<TItem extends JsonObject = JsonObject>(
-    stat: Omit<StoreFileStat, 'type'>,
-    initialData: CollectionContext<TItem>['data'] | null = null,
-  ): void {
+  newCollection(stat: Omit<StoreFileStat, 'type'>): void {
     logger.logMethodArgs?.('newCollection', stat);
     return this.newStoreFile_(
       {
         ...stat,
         type: StoreFileType.Collection,
-      },
-      initialData,
+      }
     );
   }
 

--- a/packages/engine/src/alwatr-nitrobase.ts
+++ b/packages/engine/src/alwatr-nitrobase.ts
@@ -139,17 +139,14 @@ export class AlwatrNitrobase {
    * );
    * ```
    */
-  newDocument<T extends JsonObject = JsonObject>(
-    stat: Omit<StoreFileStat, 'type'>,
-    initialData: DocumentContext<T>['data'] | null = null,
-  ): void {
+  newDocument<TDoc extends JsonObject = JsonObject>(stat: Omit<StoreFileStat, 'type'>, data: TDoc): void {
     logger.logMethodArgs?.('newDocument', stat);
     return this.newStoreFile_(
       {
         ...stat,
         type: StoreFileType.Document,
       },
-      initialData,
+      data,
     );
   }
 

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -42,7 +42,6 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
    */
   static newRefFromData<TItem extends JsonObject>(
     stat: StoreFileId,
-    initialData: CollectionContext<TItem>['data'] | null,
     updatedCallback: (from: CollectionReference<TItem>) => void,
     debugDomain?: string,
   ): CollectionReference<TItem> {
@@ -62,7 +61,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
         fv: CollectionReference.fileFormatVersion,
         extra: {},
       },
-      data: initialData ?? {},
+      data: {},
     };
 
     return new CollectionReference(initialContext, updatedCallback, debugDomain);

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -25,14 +25,14 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
    * Creates new DocumentReference instance from stat and initial data.
    *
    * @param statId the document stat.
-   * @param initialData the document data.
+   * @param data the document data.
    * @param updatedCallback the callback to invoke when the document changed.
    * @template TDoc The document data type.
    * @returns A new document reference class.
    */
   static newRefFromData<TDoc extends JsonObject>(
     statId: StoreFileId,
-    initialData: TDoc,
+    data: TDoc,
     updatedCallback: (from: DocumentReference<TDoc>) => unknown,
     debugDomain?: string,
   ): DocumentReference<TDoc> {
@@ -51,7 +51,7 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
         fv: DocumentReference.fileFormatVersion,
         extra: {},
       },
-      data: initialData,
+      data,
     };
 
     return new DocumentReference(initialContext, updatedCallback, debugDomain);


### PR DESCRIPTION
- **fix(nitrobase): required initial data  for newDocument**
- **fix(nitrobase): remove initialData parameter from newCollection method**
- **fix(nitrobase): optional data in newStoreFile_ and throw Error when data not exist for document type**
- **fix(reference): remove initialData parameter from newRefFromData method and default data to an empty object**
- **fix(reference): rename initialData parameter to data in newRefFromData method**
- **refactor(nitrobase): bind storeChanged_ method directly instead of using bind in multiple locations**
