### PR TITLE
fix: correctly bind storeChanged_

### DIFF
--- a/packages/engine/src/alwatr-nitrobase.ts
+++ b/packages/engine/src/alwatr-nitrobase.ts
@@ -95,7 +95,6 @@ export class AlwatrNitrobase {
     logger.logMethodArgs?.('new', config);
     this.config.defaultChangeDebounce ??= 40;
     this.rootDb__ = this.loadRootDb__();
-    this.storeChanged_ = this.storeChanged_.bind(this);
     exitHook(this.exitHook__.bind(this));
   }
 
@@ -434,7 +433,7 @@ export class AlwatrNitrobase {
    * @param from nitrobase file reference
    * @returns A promise that resolves when the write operation is complete.
    */
-  protected async storeChanged_<T extends JsonObject>(from: DocumentReference<T> | CollectionReference<T>): Promise<void> {
+  protected storeChanged_ = (async <T extends JsonObject>(from: DocumentReference<T> | CollectionReference<T>) => {
     logger.logMethodArgs?.('storeChanged__', from.id);
     const rev = from.getStoreMeta().rev;
     try {
@@ -447,7 +446,7 @@ export class AlwatrNitrobase {
     catch (error) {
       logger.error('storeChanged__', 'write_context_failed', {id: from.id, error});
     }
-  }
+  }).bind(this);
 
   /**
    * Load storeFilesCollection or create new one.

--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -596,7 +596,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
     if (itemId === null) this.refreshMeta_(itemId); // root meta not updated for null
 
     if (this._freeze === true) return; // prevent save if frozen
-    this.updatedCallback__.call(null, this);
+    this.updatedCallback__(this);
   }
 
   /**

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -367,7 +367,7 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
     this.refreshMetadata_();
 
     if (this._freeze === true) return; // prevent save if frozen
-    this.updatedCallback__.call(null, this);
+    this.updatedCallback__(this);
   }
 
   /**


### PR DESCRIPTION
## Description

Fix this error:

```
{
  id: '.s/.nitrobase',
  error: TypeError: Cannot read properties of null (reading 'j')
      at u (/Users/njfamirm/.yarn/berry/cache/@alwatr-nitrobase-engine-npm-7.5.4-b8b4e0da3e-10c0.zip/node_modules/@alwatr/nitrobase-engine/src/alwatr-nitrobase.ts:441:18)
      at z.n (/Users/njfamirm/.yarn/berry/cache/@alwatr-nitrobase-reference-npm-7.5.4-e5fcf4da02-10c0.zip/node_modules/@alwatr/nitrobase-reference/src/collection-reference.ts:599:28)
      at runNextTicks (node:internal/process/task_queues:65:5)
      at listOnTimeout (node:internal/timers:555:9)
      at process.processTimers (node:internal/timers:529:7)
}
```