### PR TITLE
Fix: callback context in CollectionReference and DocumentReference

### DIFF
--- a/packages/reference/src/collection-reference.ts
+++ b/packages/reference/src/collection-reference.ts
@@ -596,7 +596,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
     if (itemId === null) this.refreshMeta_(itemId); // root meta not updated for null
 
     if (this._freeze === true) return; // prevent save if frozen
-    this.updatedCallback__.call(null, this);
+    this.updatedCallback__(this);
   }
 
   /**

--- a/packages/reference/src/document-reference.ts
+++ b/packages/reference/src/document-reference.ts
@@ -367,7 +367,7 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
     this.refreshMetadata_();
 
     if (this._freeze === true) return; // prevent save if frozen
-    this.updatedCallback__.call(null, this);
+    this.updatedCallback__(this);
   }
 
   /**


### PR DESCRIPTION
Update the invocation of the updated callback to use the correct context in both CollectionReference and DocumentReference classes.